### PR TITLE
chore: Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-01-14
+
 ### Added
-- **Minimal Init Mode (`sk init --minimal`)** (PR #TBD)
+- **Minimal Init Mode (`sk init --minimal`)** (PR #207)
   - New `--minimal` flag for lightweight project initialization
   - Installs only session tracking infrastructure without templates or quality tiers
   - Ideal for simple projects (HTML sites, scripts, prototypes) that don't need testing/linting
@@ -1691,8 +1693,9 @@ Phase mapping to public release versions:
   - Phase 5.7: Spec-first architecture
   - Phase 5.8: Marketplace plugin support
   - Phase 5.9: Standard Python src/ layout & PyPI publishing
-- **v0.2.2** = Current release ✅ **Current** (Fix missing test_execution.commands config)
-- v0.2.1 = Previous release (Critical CVE patches for Next.js/React templates)
+- **v0.3.0** = Current release ✅ **Current** (Minimal init mode, bug fixes)
+- v0.2.2 = Previous release (Fix missing test_execution.commands config)
+- v0.2.1 = Earlier release (Critical CVE patches for Next.js/React templates)
 - v0.2.0 = Earlier release (Tailwind CSS v4 migration, CHANGELOG check fixes)
 - v0.1.7 = Earlier release (Improved /end command flow, slash command format)
 - v0.1.6 = Earlier release (Minimal scaffolding migration complete)

--- a/README.md
+++ b/README.md
@@ -917,7 +917,7 @@ While Claude Code is excellent for code generation and exploration, Solokit adds
 
 ## Development Status
 
-**Current Version:** v0.2.2 (Production-Ready)
+**Current Version:** v0.3.0 (Production-Ready)
 
 **Test Coverage:** 3,802 tests passing (100%), 97% code coverage
 

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -1,6 +1,6 @@
 # Solokit Roadmap
 
-**Current Release:** v0.2.2
+**Current Release:** v0.3.0
 **Status:** Production-ready, feature-complete framework
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "solokit"
-version = "0.2.2"
+version = "0.3.0"
 description = "Solokit - Structured Solo Development with AI and Quality Automation"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/solokit/__version__.py
+++ b/src/solokit/__version__.py
@@ -1,3 +1,3 @@
 """Version information for Solokit package."""
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"


### PR DESCRIPTION
## Release 0.3.0

### Added
- **Minimal Init Mode (`sk init --minimal`)** (PR #207)
  - New `--minimal` flag for lightweight project initialization
  - Installs only session tracking infrastructure without templates or quality tiers
  - Ideal for simple projects (HTML sites, scripts, prototypes)

### Fixed
- `/end` command fails on new projects with few commits
- Semgrep CI installation failure in ml_ai_fastapi template

### Changes
- `src/solokit/__version__.py`: 0.2.2 → 0.3.0
- `pyproject.toml`: 0.2.2 → 0.3.0
- `CHANGELOG.md`: Added [0.3.0] section
- `README.md`: Updated version reference
- `docs/project/ROADMAP.md`: Updated version reference

---

After merging, tag and release will be created:
```bash
git tag -a v0.3.0 -m "Release v0.3.0"
git push origin v0.3.0
gh release create v0.3.0 --title "v0.3.0" --notes-file <changelog_excerpt>
```