### PR TITLE
docs: Add meaningful test guidance to PRD and spec writing guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Meaningful Test Guidance in Documentation**
+  - Added explicit guidance that tests should represent real use cases, not just satisfy coverage metrics
+  - Updated PRD_WRITING_GUIDE.md with "Write Meaningful Tests, Not Just Coverage" section
+  - Updated writing-specs.md with new tip on scenario-driven vs coverage-driven tests
+  - Key principle: "If this feature broke in production, would this test catch it?"
+  - Helps prevent false confidence from tests that pass but don't catch real bugs
+
 ## [0.3.0] - 2026-01-14
 
 ### Added

--- a/docs/guides/writing-specs.md
+++ b/docs/guides/writing-specs.md
@@ -536,6 +536,28 @@ Future you (or Claude) will thank you:
 - What constraints were considered?
 - What assumptions are being made?
 
+### Write Meaningful Tests, Not Just Coverage
+
+Tests should validate real user scenarios, not just satisfy coverage metrics:
+
+**The test quality question:** "If this feature broke in production, would this test catch it?"
+
+```markdown
+❌ BAD: Coverage-driven tests
+- Tests that exercise code without meaningful assertions
+- Mocking everything so nothing real is verified
+- Tests that would pass even if the feature is broken
+- Writing trivial tests just to hit coverage thresholds
+
+✅ GOOD: Scenario-driven tests
+- Tests derived directly from acceptance criteria
+- Tests that verify actual user workflows end-to-end
+- Tests for edge cases and error conditions users might hit
+- Tests that would genuinely fail if functionality regressed
+```
+
+**Tip:** Each acceptance criterion should map to at least one meaningful test. If you can't write a test that would fail when the criterion isn't met, the criterion may be too vague.
+
 ---
 
 ## Common Mistakes

--- a/src/solokit/templates/guides/PRD_WRITING_GUIDE.md
+++ b/src/solokit/templates/guides/PRD_WRITING_GUIDE.md
@@ -61,6 +61,7 @@ When implementing from a PRD, Claude will:
 - Follow the exact acceptance criteria
 - Implement only what is specified (no "bonus" features)
 - Write tests that verify the acceptance criteria
+- **Write meaningful tests that represent real use cases** - Tests should validate actual user scenarios and business logic, not just exist to satisfy coverage metrics. A test that passes but doesn't catch real bugs provides false confidence.
 - Follow patterns documented in ARCHITECTURE.md
 - Ask for clarification when requirements are ambiguous
 - Use Solokit's session workflow (`/start`, `/end`)
@@ -393,6 +394,26 @@ Every story should specify:
 ---
 
 ## Testing Strategy
+
+### Write Meaningful Tests, Not Just Coverage
+
+**Critical principle:** Tests exist to catch bugs and validate real user scenarios, not to satisfy coverage metrics.
+
+```
+❌ BAD: Writing tests just for coverage
+- Tests that exercise code paths without meaningful assertions
+- Tests that mock everything and verify nothing real
+- Tests that pass but wouldn't catch actual bugs
+- Artificially inflating coverage with trivial tests
+
+✅ GOOD: Writing tests that represent real use cases
+- Tests that validate actual user workflows
+- Tests that verify business logic and edge cases
+- Tests that would fail if the feature broke
+- Tests derived from acceptance criteria scenarios
+```
+
+**Ask yourself:** "If this feature broke in production, would this test catch it?"
 
 ### Testing Pyramid
 


### PR DESCRIPTION
## Summary

- Added explicit guidance that tests should represent real use cases, not just satisfy coverage metrics
- Updated PRD_WRITING_GUIDE.md with "Write Meaningful Tests, Not Just Coverage" section in Testing Strategy
- Added to Claude's Responsibilities: tests should validate actual user scenarios
- Updated writing-specs.md with new tip on scenario-driven vs coverage-driven tests

## Motivation

Previously, documentation emphasized:
- Writing tests that verify acceptance criteria
- Meeting coverage thresholds
- Listing test categories (unit, integration, E2E)

But it never explicitly stated:
- Tests should represent real use cases and user scenarios
- Don't write tests just to hit coverage numbers
- Coverage alone doesn't equal quality

This could lead to "coverage gaming" where tests pass but wouldn't catch real bugs.

## Key Additions

**New principle introduced:** "If this feature broke in production, would this test catch it?"

**BAD (coverage-driven) examples:**
- Tests that exercise code without meaningful assertions
- Mocking everything so nothing real is verified
- Tests that would pass even if the feature is broken

**GOOD (scenario-driven) examples:**
- Tests derived directly from acceptance criteria
- Tests that verify actual user workflows end-to-end
- Tests that would genuinely fail if functionality regressed

## Test plan

- [x] Verified changes render correctly in markdown
- [x] Checked guidance integrates naturally with existing content
- [x] Updated CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)